### PR TITLE
Fix problem with `collections` module in Python >= 3.10

### DIFF
--- a/github3/session.py
+++ b/github3/session.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import requests
 
-from collections import Callable
+from collections.abc import Callable
 from . import __version__
 from logging import getLogger
 from contextlib import contextmanager

--- a/github3/structs.py
+++ b/github3/structs.py
@@ -8,7 +8,7 @@ from . import exceptions
 from . import models
 
 
-class GitHubIterator(models.GitHubCore, collections.Iterator):
+class GitHubIterator(models.GitHubCore, collections.abc.Iterator):
     """The :class:`GitHubIterator` class powers all of the iter_* methods."""
     def __init__(self, count, url, cls, session, params=None, etag=None,
                  headers=None):

--- a/github3/utils.py
+++ b/github3/utils.py
@@ -81,7 +81,7 @@ def stream_response_to_file(response, path=None):
     fd = None
     filename = None
     if path:
-        if isinstance(getattr(path, 'write', None), collections.Callable):
+        if isinstance(getattr(path, 'write', None), collections.abc.Callable):
             pre_opened = True
             fd = path
             filename = getattr(fd, 'name', None)


### PR DESCRIPTION
This PR fixes the issue related to [this module](https://docs.python.org/3/whatsnew/3.10.html#collections-abc), which breaks GitHubLMS tool that we use at UBC MDS. Basically, the only needed change is to update references to `collections` to `collections.abc` when referring to e.g. `Callable` or `Iterator` classes.